### PR TITLE
Added notHaving method 

### DIFF
--- a/lib/Plexity.php
+++ b/lib/Plexity.php
@@ -5,6 +5,7 @@ namespace Ballen\Plexity;
 use Ballen\Collection\Collection;
 use Ballen\Plexity\Interfaces\PasswordHistoryInterface;
 use Ballen\Plexity\Support\Validator;
+use InvalidArgumentException;
 
 /**
  * Plexity
@@ -22,17 +23,18 @@ use Ballen\Plexity\Support\Validator;
 class Plexity
 {
 
-    const RULE_UPPER = 'upper';
-    const RULE_LOWER = 'lower';
-    const RULE_SPECIAL = 'special';
-    const RULE_NUMERIC = 'numeric';
-    const RULE_LENGTH_MIN = 'length_min';
-    const RULE_LENGTH_MAX = 'length_max';
-    const RULE_NOT_IN = 'not_in';
+    public const RULE_UPPER = 'upper';
+    public const RULE_LOWER = 'lower';
+    public const RULE_SPECIAL = 'special';
+    public const RULE_NUMERIC = 'numeric';
+    public const RULE_LENGTH_MIN = 'length_min';
+    public const RULE_LENGTH_MAX = 'length_max';
+    public const RULE_NOT_IN = 'not_in';
+    public const RULE_NOT_HAVING = 'not_having';
 
     /**
      * The configured list of rules for the object.
-     * @var \Ballen\Collection\Collection
+     * @var Collection
      */
     private $rules;
 
@@ -54,6 +56,7 @@ class Plexity
         self::RULE_LENGTH_MIN => 0,
         self::RULE_LENGTH_MAX => 0,
         self::RULE_NOT_IN => null,
+        self::RULE_NOT_HAVING => null,
     ];
 
     /**
@@ -69,7 +72,7 @@ class Plexity
     {
         $this->rules = new Collection($this->defaultConfiguration);
 
-        $this->validator = new Validator;
+        $this->validator = new Validator();
     }
 
     /**
@@ -134,7 +137,7 @@ class Plexity
     public function minimumLength($minLength)
     {
         if (!is_int($minLength)) {
-            throw new \InvalidArgumentException('The minimum length value must be of type integer.');
+            throw new InvalidArgumentException('The minimum length value must be of type integer.');
         }
         $this->rules->put(self::RULE_LENGTH_MIN, $minLength);
         return $this;
@@ -148,7 +151,7 @@ class Plexity
     public function maximumLength($maxLength)
     {
         if (!is_int($maxLength)) {
-            throw new \InvalidArgumentException('The maximum length value must be of type integer.');
+            throw new InvalidArgumentException('The maximum length value must be of type integer.');
         }
         $this->rules->put(self::RULE_LENGTH_MAX, $maxLength);
         return $this;
@@ -175,6 +178,17 @@ class Plexity
     public function notIn($history)
     {
         $this->rules->put(self::RULE_NOT_IN, $history);
+        return $this;
+    }
+
+    /**
+     * Requires that the password/string doesn't contain any of the provided strings. Check is case-insensitive.
+     * @param array<string> $stack An array of strings to check against.
+     * @return Plexity
+     */
+    public function notHaving($stack)
+    {
+        $this->rules->put(self::RULE_NOT_HAVING, $stack);
         return $this;
     }
 

--- a/lib/Support/Validator.php
+++ b/lib/Support/Validator.php
@@ -111,6 +111,7 @@ class Validator
         $this->checkNumericCharacters();
         $this->checkSpecialCharacters();
         $this->checkNotIn();
+        $this->checkNotHaving();
         return true;
     }
 
@@ -216,6 +217,24 @@ class Validator
 
         if (is_array($this->configuration->rules()->get(Plexity::RULE_NOT_IN)) && count($this->configuration->rules()->get(Plexity::RULE_NOT_IN)) > 0) {
             $this->validateNotInArray();
+        }
+
+    }
+
+    /**
+     * Validates if a string does not contain any words from the provided array.
+     * @return void
+     * @throws ValidationException
+     */
+    public function checkNotHaving()
+    {
+
+        if ($this->configuration->rules()->get(Plexity::RULE_NOT_HAVING) === null) {
+            return;
+        }
+
+        if (is_array($this->configuration->rules()->get(Plexity::RULE_NOT_HAVING)) && count($this->configuration->rules()->get(Plexity::RULE_NOT_HAVING)) > 0) {
+            $this->validateNotHaving();
         }
 
     }
@@ -338,5 +357,19 @@ class Validator
             $count += substr_count($haystack, $char);
         }
         return $count;
+    }
+
+    /**
+     * Validates the not_having requirements against a simple array.
+     * @return void
+     * @throws ValidationException
+     */
+    private function validateNotHaving()
+    {
+        foreach((array)$this->configuration->rules()->get(Plexity::RULE_NOT_HAVING) as $needle){
+            if ( stripos($this->configuration->checkString() , $needle) !== false) {
+                throw new ValidationException('The string contains word from the list of disallowed values requirements.');
+            }
+        }
     }
 }

--- a/tests/PlexityTest.php
+++ b/tests/PlexityTest.php
@@ -302,4 +302,22 @@ class PlexityTest extends TestCase
         $password->notIn($passwordHistoryStore);
         $this->assertTrue($password->check('Bingo!'));
     }
+
+    public function testPasswordNotHavingWords()
+    {
+        $password = new Plexity();
+        $password->notHaving(['sol', 'red', 'joe', 'Pot']);
+        $this->assertTrue($password->check('S0l7y5'));
+    }
+
+    public function testPasswordNotHavingWordsFail()
+    {
+        $password = new Plexity();
+        $password->notHaving(['sol', 'red', 'joe', 'Pot']);
+        $this->expectException(
+            'Ballen\Plexity\Exceptions\ValidationException',
+            'The string contains word from the list of disallowed values requirements.'
+        );
+        $password->check('%tRedRig7');
+    }
 }


### PR DESCRIPTION
Added `notHaving()` method to test if password / string does not contain any of the strings from provided list.
I would use `str_contains` but package wouldn't then support PHP < 8.0

Labelling this PR as `HACKTOBERFEST-ACCEPTED` would be really appreciated if accepted ;)